### PR TITLE
fix: avoid triggering direnv when resolving repo root

### DIFF
--- a/cmux.sh
+++ b/cmux.sh
@@ -61,11 +61,12 @@ cmux() {
 # ── Helpers ──────────────────────────────────────────────────────────
 
 # Get the repo root from anywhere (works inside worktrees too)
+# Uses realpath instead of cd to avoid triggering direnv/shell hooks
 _cmux_repo_root() {
   local git_common_dir
   git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
   # --git-common-dir returns the .git dir; parent is repo root
-  (cd "$(dirname "$git_common_dir")" && pwd)
+  realpath "$(dirname "$git_common_dir")"
 }
 
 # Sanitize branch name: slashes become hyphens


### PR DESCRIPTION
## Summary

Running any `cmux` command from inside a worktree triggers direnv to load the primary checkout's `.envrc`, producing noisy output like:

```
direnv: loading ~/acmedev/repo/.envrc
direnv: export +DATABASE_URL +API_KEY +NODE_ENV +AWS_REGION ...
```

**Root cause:** `_cmux_repo_root` uses `(cd ... && pwd)` in a subshell to resolve the repo root path. When in a worktree, `git rev-parse --git-common-dir` returns a relative path back to the main repo's `.git`. The `cd` into that directory triggers zsh's `chpwd` hook (and bash's `PROMPT_COMMAND`), which fires direnv even inside subshells.

**Fix:** Replace the subshell `cd`/`pwd` with `realpath`, which resolves the path purely via filesystem path resolution — no directory change, no shell hooks triggered.

**Note:** `realpath` is not POSIX but is available on macOS (built-in since Monterey) and all modern Linux distros. This matches cmux's target audience (macOS/Linux devs using Claude Code).

## Test plan

- [ ] `cmux ls` from inside a worktree no longer triggers direnv output
- [ ] `_cmux_repo_root` still resolves to the correct absolute path from worktrees
- [ ] `_cmux_repo_root` still works from the primary checkout
- [ ] Verify `realpath` is available on target platforms (macOS 12+, Ubuntu 20.04+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)