### PR TITLE
docs: add Community section with orchestration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ You never have to remember branch names. Built-in completion for bash and zsh �
 - `cmux merge <TAB>` — worktree branches
 - `cmux init <TAB>` — `--replace`
 
+## Community
+
+| Project | Description |
+|---------|-------------|
+| [claude-orchestration-in-cmux](https://github.com/baixianger/claude-orchestration-in-cmux) | Claude Code skill that turns one session into an orchestrator -- discovers panes, delegates tasks to other Claude sessions, monitors progress via screen polling, and manages the full commit-merge-rebase cycle with worktree isolation. |
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Adds a **Community** section to the README for community-built tools and skills that extend cmux
- First entry: [claude-orchestration-in-cmux](https://github.com/baixianger/claude-orchestration-in-cmux), a Claude Code skill for multi-session orchestration

## Context

I've been using cmux daily and it works like a charm. The workspace feature in particular inspired me to build a Claude Code skill on top of it -- one session acts as an orchestrator that discovers panes, delegates tasks to other Claude sessions, monitors their progress via screen polling, and manages the full commit-merge-rebase cycle with worktree isolation.

It's become a core part of my workflow and I thought other cmux users might find it useful too. Happy to adjust the section format or placement if you have preferences.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify the link to the skill repo resolves