### PR TITLE
feat: show merge status in cmux ls output

### DIFF
--- a/cmux.sh
+++ b/cmux.sh
@@ -388,7 +388,10 @@ _cmux_ls() {
   if [[ "$1" == "--help" || "$1" == "-h" ]]; then
     echo "Usage: cmux ls"
     echo ""
-    echo "  List all cmux worktrees."
+    echo "  List all cmux worktrees with merge status."
+    echo "  Status indicators:"
+    echo "    [merged]    Branch is fully merged into the primary branch"
+    echo "    [ahead N]   Branch is N commits ahead of the primary branch"
     return 0
   fi
   local repo_root
@@ -402,7 +405,31 @@ _cmux_ls() {
     sibling)      filter="$(dirname "$repo_root")/$(basename "$repo_root")-" ;;
     *)            filter="$(_cmux_worktree_base "$repo_root")/" ;;
   esac
-  git -C "$repo_root" worktree list | grep -F "$filter"
+
+  # Determine the primary branch for merge status comparison
+  local primary_branch
+  primary_branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+
+  while IFS= read -r line; do
+    # Extract branch name from worktree list output (format: /path  hash [branch])
+    local branch
+    branch="$(echo "$line" | sed -n 's/.*\[\(.*\)\].*/\1/p')"
+
+    if [[ -n "$branch" && -n "$primary_branch" && "$branch" != "$primary_branch" ]]; then
+      local ahead
+      ahead="$(git -C "$repo_root" rev-list --count "$primary_branch".."$branch" 2>/dev/null)"
+
+      if [[ "$ahead" == "0" ]]; then
+        echo "$line  [merged]"
+      elif [[ -n "$ahead" ]]; then
+        echo "$line  [ahead $ahead]"
+      else
+        echo "$line"
+      fi
+    else
+      echo "$line"
+    fi
+  done < <(git -C "$repo_root" worktree list | grep -F "$filter")
 }
 
 _cmux_merge() {


### PR DESCRIPTION
## Problem

When running `cmux ls` you just see a list of worktrees with their paths and branches. But there is no way to know which branches are already merged and which still have work pending. This makes the daily cleanup workflow harder because you have to manually check each branch before removing.

I had the same problem - I was running `git log main..branch` for each worktree to see if it was safe to remove.

## What I changed

Enhanced `_cmux_ls()` to append merge status after each worktree line:

```
/path/to/repo/.worktrees/fix-auth  abc1234 [fix-auth]  [merged]
/path/to/repo/.worktrees/new-feat  def5678 [new-feat]  [ahead 3]
```

**Status indicators:**
- `[merged]` - branch has 0 commits ahead of primary branch (safe to remove)
- `[ahead N]` - branch has N commits not yet in the primary branch

**How it works:**
1. Gets the primary branch from `git rev-parse --abbrev-ref HEAD` in the repo root
2. For each worktree, extracts the branch name from `git worktree list` output
3. Uses `git rev-list --count primary..branch` to count unmerged commits
4. Appends the status tag to each line

If git commands fail (detached HEAD, etc.), the line is printed without status - no breakage.

## Updated help text

Also updated `cmux ls --help` to document the new status indicators.

## Testing

- `bash -n cmux.sh` passes (syntax valid)
- Works with all 3 layout modes (outer-nested, sibling, default)
- Gracefully handles: no worktrees, detached HEAD, primary branch not determinable

Closes #10