### PR TITLE
fix: use cygpath -ma on Windows so cmux ls path filter matches

### DIFF
--- a/cmux.sh
+++ b/cmux.sh
@@ -66,13 +66,26 @@ cmux() {
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
+# Canonical path resolver that produces a format compatible with `git worktree list`.
+# On Windows (Git Bash / MSYS), `realpath` returns POSIX form (/c/Users/...) while
+# `git worktree list` returns mixed form (C:/Users/...), breaking path-prefix filters
+# used by `cmux ls` and similar. Use `cygpath -ma` on Windows to produce an absolute
+# mixed-form path. Falls back to `realpath` everywhere else.
+_cmux_canonical_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -ma "$1" 2>/dev/null
+  else
+    realpath "$1"
+  fi
+}
+
 # Get the repo root from anywhere (works inside worktrees too)
-# Uses realpath instead of cd to avoid triggering direnv/shell hooks
+# Uses _cmux_canonical_path instead of cd to avoid triggering direnv/shell hooks
 _cmux_repo_root() {
   local git_common_dir
   git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
   # --git-common-dir returns the .git dir; parent is repo root
-  realpath "$(dirname "$git_common_dir")"
+  _cmux_canonical_path "$(dirname "$git_common_dir")"
 }
 
 # Detect the repo's default branch (main, master, etc.)


### PR DESCRIPTION
Fixes #22

## Problem

On Windows (Git Bash / MSYS), `cmux ls` and `cmux rm --all` silently return empty because the path filter never matches:

- `realpath` on MSYS returns POSIX form: `/c/Users/foo/repo`
- `git worktree list` emits mixed form: `C:/Users/foo/repo`
- `grep -F "$filter"` comparing these two strings yields zero matches

## Fix

Introduce `_cmux_canonical_path` helper that prefers `cygpath -ma` (absolute + mixed format) when available, falling back to `realpath` everywhere else. `_cmux_repo_root` delegates to this helper.

- Linux/macOS behavior: unchanged (no `cygpath` on PATH → realpath branch runs)
- Windows behavior: path now matches `git worktree list` output format

## Verification

On Windows Git Bash (MSYS2/MINGW64, bash 5.2.37, git 2.52.0.windows.1):

```bash
$ cd /c/Users/foo/repo
$ cmux new test-branch
# ...worktree created successfully
$ cmux ls
C:/Users/foo/repo/.worktrees/test-branch   hash [test-branch]  [ahead 1]
$ cmux rm test-branch -f
Deleted branch test-branch.
Removed worktree and branch: test-branch
$ cmux ls
# (empty, as expected)
```

Before the fix: `cmux ls` always empty. After the fix: worktrees are listed correctly.

Linux path (unchanged): running the same code in a non-MSYS environment takes the `realpath` branch since `cygpath` is not available.

## Scope

Minimal one-function change (`cmux.sh`, +15 / -2). No new dependencies, no test additions (repo has no test suite per `CLAUDE.md`).